### PR TITLE
Disable grooveshark inactivity timeout

### DIFF
--- a/content.js
+++ b/content.js
@@ -133,6 +133,10 @@ Provider.prototype.checkStatus = function() {
 			break;
 
 		case "grooveshark.com":
+			var p = document.querySelector('.lightbox-interactionTimeout .submit');
+			if (p) {
+				p.click();
+			}
 			status = document.getElementById('play-pause').classList.contains('playing') ? 'playing' : 'paused';
 			break;
 		/*


### PR DESCRIPTION
Really helpful feature (in case you don't have payed account). Automatically closes timeout popup, which allows to listen music the whole day. 
Tested in one working day.
