### PR TITLE
Catch the failing tab message

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
     "name": "StoPlay",
     "short_name": "StoPlay",
     "homepage_url": "http://stoplay.github.io/",
-    "version": "1.1.66",
+    "version": "1.1.67",
     "author": [
         {
             "name": "Alex Karpov",

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
     "name": "StoPlay",
     "short_name": "StoPlay",
     "homepage_url": "http://stoplay.github.io/",
-    "version": "1.1.65",
+    "version": "1.1.66",
     "author": [
         {
             "name": "Alex Karpov",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stoplayExt-build",
-  "version": "1.1.65",
+  "version": "1.1.66",
   "author": "Alex Buznik",
   "scripts": {
     "build": "grunt rollup",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stoplayExt-build",
-  "version": "1.1.66",
+  "version": "1.1.67",
   "author": "Alex Buznik",
   "scripts": {
     "build": "grunt rollup",

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -155,12 +155,17 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 			const hasLastPlayingTabId = Boolean(lastPausedTabId);
 			const senderIsNotLastPlaying = sender.tab.id !== lastPausedTabId;
 
+			// pause previously playing tab
 			if (hasLastPlayingTabId && senderIsNotLastPlaying || isFrameIdChanged) {
+				try {
 				chrome.tabs.sendMessage(
 					lastPlayingTabId,
 					{action: Actions.PAUSE},
 					{frameId: lastPlayingFrameId}
 				);
+				} catch(err) {
+					console.log('err in pausing prev tab', err);
+				}
 			}
 
 			appState.setLastPlayingTabId(sender.tab.id);

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -152,20 +152,16 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 
 		case 'started':
 			const isFrameIdChanged = (lastPlayingTabId && sender.frameId != lastPlayingFrameId);
-			const hasLastPlayingTabId = Boolean(lastPausedTabId);
+			const hasLastPlayingTabId = Boolean(lastPlayingTabId);
 			const senderIsNotLastPlaying = sender.tab.id !== lastPausedTabId;
 
 			// pause previously playing tab
 			if (hasLastPlayingTabId && senderIsNotLastPlaying || isFrameIdChanged) {
-				try {
 				chrome.tabs.sendMessage(
 					lastPlayingTabId,
 					{action: Actions.PAUSE},
 					{frameId: lastPlayingFrameId}
 				);
-				} catch(err) {
-					console.log('err in pausing prev tab', err);
-				}
 			}
 
 			appState.setLastPlayingTabId(sender.tab.id);


### PR DESCRIPTION
There is an error appeared that breaks background process.

My best guess is that it happens when trying to send a message to a closed tab.
This is should not happen since we nullify the last tab playing id here https://github.com/StoPlay/stoplay-ext/blob/develop/src/background/index.js#L239
But I don't have better ideas.